### PR TITLE
Variable unit id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,125 @@
+
+# Created by https://www.toptal.com/developers/gitignore/api/xcode,objective-c,macos,vscode
+# Edit at https://www.toptal.com/developers/gitignore?templates=xcode,objective-c,macos,vscode
+
+### macOS ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+### Objective-C ###
+# Xcode
+#
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+## User settings
+xcuserdata/
+
+## compatibility with Xcode 8 and earlier (ignoring not required starting Xcode 9)
+*.xcscmblueprint
+*.xccheckout
+
+## compatibility with Xcode 3 and earlier (ignoring not required starting Xcode 4)
+build/
+DerivedData/
+*.moved-aside
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+
+## Obj-C/Swift specific
+*.hmap
+
+## App packaging
+*.ipa
+*.dSYM.zip
+*.dSYM
+
+# CocoaPods
+# We recommend against adding the Pods directory to your .gitignore. However
+# you should judge for yourself, the pros and cons are mentioned at:
+# https://guides.cocoapods.org/using/using-cocoapods.html#should-i-check-the-pods-directory-into-source-control
+# Pods/
+# Add this line if you want to avoid checking in source code from the Xcode workspace
+# *.xcworkspace
+
+# Carthage
+# Add this line if you want to avoid checking in source code from Carthage dependencies.
+# Carthage/Checkouts
+
+Carthage/Build/
+
+# fastlane
+# It is recommended to not store the screenshots in the git repo.
+# Instead, use fastlane to re-generate the screenshots whenever they are needed.
+# For more information about the recommended setup visit:
+# https://docs.fastlane.tools/best-practices/source-control/#source-control
+
+fastlane/report.xml
+fastlane/Preview.html
+fastlane/screenshots/**/*.png
+fastlane/test_output
+
+# Code Injection
+# After new code Injection tools there's a generated folder /iOSInjectionProject
+# https://github.com/johnno1962/injectionforxcode
+
+iOSInjectionProject/
+
+### Objective-C Patch ###
+
+### vscode ###
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+*.code-workspace
+
+### Xcode ###
+# Xcode
+# gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
+
+
+
+
+## Gcc Patch
+/*.gcno
+
+### Xcode Patch ###
+*.xcodeproj/*
+!*.xcodeproj/project.pbxproj
+!*.xcodeproj/xcshareddata/
+!*.xcworkspace/contents.xcworkspacedata
+**/xcshareddata/WorkspaceSettings.xcsettings
+
+# End of https://www.toptal.com/developers/gitignore/api/xcode,objective-c,macos,vscode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.1.0]
+Baseline release to open source.
+
+## [1.2.0] - 2021-04-25
+### Fixed
+- Several issues reported with some camera's ProcessingUnit being available but unusable.  Diagnosed as the use of a static unit id of 2 for the ProcessingUnit, whereas the UVC standard has a variable unit id present in the PU header.  Added unit id map to UVCController with default unit ids for each handled unit type, overridden by unit id from the unit's header record.  User who reported issues tested the change, confirmed success.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # uvc-util
 USB Video Class (UVC) control management utility for Mac OS X
 
-This code arose from a need for a command-line utility on Mac OS X that could query and modify UVC camera controls (like contrast and brightness).  It presently implements all Terminal and Processing Unit controls available under the [1.1 standard](http://www.cajunbot.com/wiki/images/8/85/USB_Video_Class_1.1.pdf "UVC 1.1 PDF").
+This code arose from a need for a command-line utility on Mac OS X that could query and modify UVC camera controls (like contrast and brightness).  It presently implements all Terminal and Processing Unit controls available under the [1.1 standard](http://www.cajunbot.com/wiki/images/8/85/USB_Video_Class_1.1.pdf "UVC 1.1 PDF").  Additional [1.5 standard](https://www.usb.org/sites/default/files/USB_Video_Class_1_5.zip) terminal- and processing-unit properties were added for the 1.2 release of this software.
 
 Control values are implemented using a class (UVCType) that represents byte-packed data structures containing core atomic types (8-, 16-, 32-, and 64-bit integers).  Multi-component types allow fields to be named.  Another class (UVCValue) uses UVCType and a memory buffer to manage data structured according to that UVCType.  Thus, the code knows how each implemented UVC control's data is structured, which allows for per-component byte-swapping when necessary, etc.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # uvc-util
 USB Video Class (UVC) control management utility for Mac OS X
 
-This code arose from a need for a command-line utility on Mac OS X that could query and modify UVC camera controls (like contrast and brightness).  It presently implements all Terminal and Processing Unit controls available under the [1.1 standard](http://www.cajunbot.com/wiki/images/8/85/USB_Video_Class_1.1.pdf "UVC 1.1 PDF").  Additional [1.5 standard](https://www.usb.org/sites/default/files/USB_Video_Class_1_5.zip) terminal- and processing-unit properties were added for the 1.2 release of this software.
+This code arose from a need for a command-line utility on Mac OS X that could query and modify UVC camera controls (like contrast and brightness).  It presently implements all Terminal and Processing Unit controls available under the [1.1 standard](http://www.cajunbot.com/wiki/images/8/85/USB_Video_Class_1.1.pdf "UVC 1.1 PDF").  Additional [1.5 standard](https://www.usb.org/sites/default/files/USB_Video_Class_1_5.zip) Terminal and Processing Unit controls were added for the 1.2 release of this software.
 
 Control values are implemented using a class (UVCType) that represents byte-packed data structures containing core atomic types (8-, 16-, 32-, and 64-bit integers).  Multi-component types allow fields to be named.  Another class (UVCValue) uses UVCType and a memory buffer to manage data structured according to that UVCType.  Thus, the code knows how each implemented UVC control's data is structured, which allows for per-component byte-swapping when necessary, etc.
 

--- a/src/UVCController.h
+++ b/src/UVCController.h
@@ -48,6 +48,7 @@
   BOOL                          _isInterfaceOpen;
   uint8_t                       _videoInterfaceIndex;
   NSMutableDictionary           *_controls;
+  NSMutableDictionary           *_unitIds;
   UInt16                        _uvcVersion;
   NSData                        *_terminalControlsAvailable;
   NSData                        *_processingUnitControlsAvailable;

--- a/src/UVCController.h
+++ b/src/UVCController.h
@@ -368,7 +368,11 @@ FOUNDATION_EXPORT NSString *UVCTerminalControlPanTiltAbsolute;
 FOUNDATION_EXPORT NSString *UVCTerminalControlPanTiltRelative;
 FOUNDATION_EXPORT NSString *UVCTerminalControlRollAbsolute;
 FOUNDATION_EXPORT NSString *UVCTerminalControlRollRelative;
+FOUNDATION_EXPORT NSString *UVCTerminalControlFocusAuto;
 FOUNDATION_EXPORT NSString *UVCTerminalControlPrivacy;
+FOUNDATION_EXPORT NSString *UVCTerminalControlFocusSimple;
+FOUNDATION_EXPORT NSString *UVCTerminalControlWindow;
+FOUNDATION_EXPORT NSString *UVCTerminalControlRegionOfInterest;
 
 //
 // Control names, Processing Unit
@@ -391,3 +395,4 @@ FOUNDATION_EXPORT NSString *UVCProcessingUnitControlDigitalMultiplierLimit;
 FOUNDATION_EXPORT NSString *UVCProcessingUnitControlAutoHue;
 FOUNDATION_EXPORT NSString *UVCProcessingUnitControlAnalogVideoStandard;
 FOUNDATION_EXPORT NSString *UVCProcessingUnitControlAnalogLockStatus;
+FOUNDATION_EXPORT NSString *UVCProcessingUnitControlAutoContrast;

--- a/src/UVCController.m
+++ b/src/UVCController.m
@@ -84,8 +84,11 @@ enum {
   kUVCTerminalControlEnablePanTiltRelative        = 12,
   kUVCTerminalControlEnableRollAbsolute           = 13,
   kUVCTerminalControlEnableRollRelative           = 14,
-  kUVCTerminalControlEnableAutoFocus              = 17,
-  kUVCTerminalControlEnablePrivacy                = 18
+  kUVCTerminalControlEnableFocusAuto              = 17,
+  kUVCTerminalControlEnablePrivacy                = 18,
+  kUVCTerminalControlEnableFocusSimple            = 19,
+  kUVCTerminalControlEnableWindow                 = 20,
+  kUVCTerminalControlEnableRegionOfInterest       = 21
 };
 
 typedef struct {
@@ -126,7 +129,8 @@ enum {
   kUVCProcessingUnitControlEnableDigitalMultiplier            = 14,
   kUVCProcessingUnitControlEnableDigitalMultiplierLimit       = 15,
   kUVCProcessingUnitControlEnableAnalogVideoStandard          = 16,
-  kUVCProcessingUnitControlEnableAnalogVideoLockStatus        = 17
+  kUVCProcessingUnitControlEnableAnalogVideoLockStatus        = 17,
+  kUVCProcessingUnitControlEnableAutoContrast                 = 18
 };
 
 //
@@ -163,6 +167,9 @@ enum {
 #define CT_ROLL_ABSOLUTE_CONTROL                  0x0f
 #define CT_ROLL_RELATIVE_CONTROL                  0x10
 #define CT_PRIVACY_CONTROL                        0x11
+#define CT_FOCUS_SIMPLE_CONTROL                   0x12
+#define CT_WINDOW_CONTROL                         0x13
+#define CT_REGION_OF_INTEREST_CONTROL             0x14
 
 //
 // Processing-unit controls:
@@ -187,6 +194,7 @@ enum {
 #define PU_HUE_AUTO_CONTROL                       0x10
 #define PU_ANALOG_VIDEO_STANDARD_CONTROL          0x11
 #define PU_ANALOG_LOCK_STATUS_CONTROL             0x12
+#define PU_CONTRAST_AUTO_CONTROL                  0x13
 
 /*!
   @enum UVC control capabilities
@@ -282,7 +290,7 @@ typedef struct {
 */
 uvc_control_t     UVCControllerControls[] = {
                       UVC_CONTROL_INIT(UVC_INPUT_TERMINAL_ID, CT_SCANNING_MODE_CONTROL, "{B}"),
-                      UVC_CONTROL_INIT(UVC_INPUT_TERMINAL_ID, CT_AE_MODE_CONTROL, "{M}"),
+                      UVC_CONTROL_INIT(UVC_INPUT_TERMINAL_ID, CT_AE_MODE_CONTROL, "{M1}"),
                       UVC_CONTROL_INIT(UVC_INPUT_TERMINAL_ID, CT_AE_PRIORITY_CONTROL, "{U1}"),
                       UVC_CONTROL_INIT(UVC_INPUT_TERMINAL_ID, CT_EXPOSURE_TIME_ABSOLUTE_CONTROL, "{U4}"),
                       UVC_CONTROL_INIT(UVC_INPUT_TERMINAL_ID, CT_EXPOSURE_TIME_RELATIVE_CONTROL, "{S1}"),
@@ -298,6 +306,9 @@ uvc_control_t     UVCControllerControls[] = {
                       UVC_CONTROL_INIT(UVC_INPUT_TERMINAL_ID, CT_ROLL_ABSOLUTE_CONTROL, "{S2}"),
                       UVC_CONTROL_INIT(UVC_INPUT_TERMINAL_ID, CT_ROLL_RELATIVE_CONTROL, "{S1 roll-relative; U1 roll-speed}"),
                       UVC_CONTROL_INIT(UVC_INPUT_TERMINAL_ID, CT_PRIVACY_CONTROL, "{B}"),
+                      UVC_CONTROL_INIT(UVC_INPUT_TERMINAL_ID, CT_FOCUS_SIMPLE_CONTROL, "{U1}"),
+                      UVC_CONTROL_INIT(UVC_INPUT_TERMINAL_ID, CT_WINDOW_CONTROL, "{U2 window-top; U2 window-left; U2 window-bottom; U2 window-right; U2 num-steps; M2 num-steps-units}"),
+                      UVC_CONTROL_INIT(UVC_INPUT_TERMINAL_ID, CT_REGION_OF_INTEREST_CONTROL, "{U2 roi-top; U2 roi-left; U2 roi-bottom; U2 roi-right; M2 auto-controls}"),
                       //
                       UVC_CONTROL_INIT(UVC_PROCESSING_UNIT_ID, PU_BACKLIGHT_COMPENSATION_CONTROL, "{U2}"),
                       UVC_CONTROL_INIT(UVC_PROCESSING_UNIT_ID, PU_BRIGHTNESS_CONTROL, "{S2}"),
@@ -316,7 +327,8 @@ uvc_control_t     UVCControllerControls[] = {
                       UVC_CONTROL_INIT(UVC_PROCESSING_UNIT_ID, PU_DIGITAL_MULTIPLIER_LIMIT_CONTROL, "{U2}"),
                       UVC_CONTROL_INIT(UVC_PROCESSING_UNIT_ID, PU_HUE_AUTO_CONTROL,"{B}"),
                       UVC_CONTROL_INIT(UVC_PROCESSING_UNIT_ID, PU_ANALOG_VIDEO_STANDARD_CONTROL, "{U1}"),
-                      UVC_CONTROL_INIT(UVC_PROCESSING_UNIT_ID, PU_ANALOG_LOCK_STATUS_CONTROL, "{U1}")
+                      UVC_CONTROL_INIT(UVC_PROCESSING_UNIT_ID, PU_ANALOG_LOCK_STATUS_CONTROL, "{U1}"),
+                      UVC_CONTROL_INIT(UVC_PROCESSING_UNIT_ID, PU_CONTRAST_AUTO_CONTROL, "{U1}")
                     };
 
 /*!
@@ -552,25 +564,29 @@ uvc_control_t     UVCControllerControls[] = {
                                   [NSNumber numberWithInt:14], UVCTerminalControlRollAbsolute,
                                   [NSNumber numberWithInt:15], UVCTerminalControlRollRelative,
                                   [NSNumber numberWithInt:16], UVCTerminalControlPrivacy,
+                                  [NSNumber numberWithInt:17], UVCTerminalControlFocusSimple,
+                                  [NSNumber numberWithInt:18], UVCTerminalControlWindow,
+                                  [NSNumber numberWithInt:19], UVCTerminalControlRegionOfInterest,
 
-                                  [NSNumber numberWithInt:17], UVCProcessingUnitControlBacklightCompensation,
-                                  [NSNumber numberWithInt:18], UVCProcessingUnitControlBrightness,
-                                  [NSNumber numberWithInt:19], UVCProcessingUnitControlContrast,
-                                  [NSNumber numberWithInt:20], UVCProcessingUnitControlGain,
-                                  [NSNumber numberWithInt:21], UVCProcessingUnitControlPowerLineFrequency,
-                                  [NSNumber numberWithInt:22], UVCProcessingUnitControlHue,
-                                  [NSNumber numberWithInt:23], UVCProcessingUnitControlSaturation,
-                                  [NSNumber numberWithInt:24], UVCProcessingUnitControlSharpness,
-                                  [NSNumber numberWithInt:25], UVCProcessingUnitControlGamma,
-                                  [NSNumber numberWithInt:26], UVCProcessingUnitControlWhiteBalanceTemperature,
-                                  [NSNumber numberWithInt:27], UVCProcessingUnitControlAutoWhiteBalanceTemperature,
-                                  [NSNumber numberWithInt:28], UVCProcessingUnitControlWhiteBalanceComponent,
-                                  [NSNumber numberWithInt:29], UVCProcessingUnitControlAutoWhiteBalanceComponent,
-                                  [NSNumber numberWithInt:30], UVCProcessingUnitControlDigitalMultiplier,
-                                  [NSNumber numberWithInt:31], UVCProcessingUnitControlDigitalMultiplierLimit,
-                                  [NSNumber numberWithInt:32], UVCProcessingUnitControlAutoHue,
-                                  [NSNumber numberWithInt:33], UVCProcessingUnitControlAnalogVideoStandard,
-                                  [NSNumber numberWithInt:34], UVCProcessingUnitControlAnalogLockStatus,
+                                  [NSNumber numberWithInt:20], UVCProcessingUnitControlBacklightCompensation,
+                                  [NSNumber numberWithInt:21], UVCProcessingUnitControlBrightness,
+                                  [NSNumber numberWithInt:22], UVCProcessingUnitControlContrast,
+                                  [NSNumber numberWithInt:23], UVCProcessingUnitControlGain,
+                                  [NSNumber numberWithInt:24], UVCProcessingUnitControlPowerLineFrequency,
+                                  [NSNumber numberWithInt:25], UVCProcessingUnitControlHue,
+                                  [NSNumber numberWithInt:26], UVCProcessingUnitControlSaturation,
+                                  [NSNumber numberWithInt:27], UVCProcessingUnitControlSharpness,
+                                  [NSNumber numberWithInt:28], UVCProcessingUnitControlGamma,
+                                  [NSNumber numberWithInt:29], UVCProcessingUnitControlWhiteBalanceTemperature,
+                                  [NSNumber numberWithInt:30], UVCProcessingUnitControlAutoWhiteBalanceTemperature,
+                                  [NSNumber numberWithInt:31], UVCProcessingUnitControlWhiteBalanceComponent,
+                                  [NSNumber numberWithInt:32], UVCProcessingUnitControlAutoWhiteBalanceComponent,
+                                  [NSNumber numberWithInt:33], UVCProcessingUnitControlDigitalMultiplier,
+                                  [NSNumber numberWithInt:34], UVCProcessingUnitControlDigitalMultiplierLimit,
+                                  [NSNumber numberWithInt:35], UVCProcessingUnitControlAutoHue,
+                                  [NSNumber numberWithInt:36], UVCProcessingUnitControlAnalogVideoStandard,
+                                  [NSNumber numberWithInt:37], UVCProcessingUnitControlAnalogLockStatus,
+                                  [NSNumber numberWithInt:38], UVCProcessingUnitControlAutoContrast,
                                   nil
                                 ];
     }
@@ -596,7 +612,6 @@ uvc_control_t     UVCControllerControls[] = {
                                               [NSNumber numberWithInt:kUVCTerminalControlEnableExposureTimeRelative], UVCTerminalControlExposureTimeRelative,
                                               [NSNumber numberWithInt:kUVCTerminalControlEnableFocusAbsolute], UVCTerminalControlFocusAbsolute,
                                               [NSNumber numberWithInt:kUVCTerminalControlEnableFocusRelative], UVCTerminalControlFocusRelative,
-                                              [NSNumber numberWithInt:kUVCTerminalControlEnableAutoFocus], UVCTerminalControlAutoFocus,
                                               [NSNumber numberWithInt:kUVCTerminalControlEnableIrisAbsolute], UVCTerminalControlIrisAbsolute,
                                               [NSNumber numberWithInt:kUVCTerminalControlEnableIrisRelative], UVCTerminalControlIrisRelative,
                                               [NSNumber numberWithInt:kUVCTerminalControlEnableZoomAbsolute], UVCTerminalControlZoomAbsolute,
@@ -605,7 +620,11 @@ uvc_control_t     UVCControllerControls[] = {
                                               [NSNumber numberWithInt:kUVCTerminalControlEnablePanTiltRelative], UVCTerminalControlPanTiltRelative,
                                               [NSNumber numberWithInt:kUVCTerminalControlEnableRollAbsolute], UVCTerminalControlRollAbsolute,
                                               [NSNumber numberWithInt:kUVCTerminalControlEnableRollRelative], UVCTerminalControlRollRelative,
+                                              [NSNumber numberWithInt:kUVCTerminalControlEnableFocusAuto], UVCTerminalControlAutoFocus,
                                               [NSNumber numberWithInt:kUVCTerminalControlEnablePrivacy], UVCTerminalControlPrivacy,
+                                              [NSNumber numberWithInt:kUVCTerminalControlEnableFocusSimple], UVCTerminalControlFocusSimple,
+                                              [NSNumber numberWithInt:kUVCTerminalControlEnableWindow], UVCTerminalControlWindow,
+                                              [NSNumber numberWithInt:kUVCTerminalControlEnableRegionOfInterest], UVCTerminalControlRegionOfInterest,
                                               nil
                                             ];
     }
@@ -642,6 +661,7 @@ uvc_control_t     UVCControllerControls[] = {
                                                     [NSNumber numberWithInt:kUVCProcessingUnitControlEnableDigitalMultiplierLimit], UVCProcessingUnitControlDigitalMultiplierLimit,
                                                     [NSNumber numberWithInt:kUVCProcessingUnitControlEnableAnalogVideoStandard], UVCProcessingUnitControlAnalogVideoStandard,
                                                     [NSNumber numberWithInt:kUVCProcessingUnitControlEnableAnalogVideoLockStatus], UVCProcessingUnitControlAnalogLockStatus,
+                                                    [NSNumber numberWithInt:kUVCProcessingUnitControlEnableAutoContrast], UVCProcessingUnitControlAutoContrast,
                                                     nil
                                                   ];
     }
@@ -1483,7 +1503,10 @@ uvc_control_t     UVCControllerControls[] = {
     if ( [self hasDefaultValue] ) {
       [asString appendFormat:@"\n  default-value: %@", [_defaultValue stringValue]];
     }
-    [asString appendFormat:@"\n  current-value: %@", [[self currentValue]  stringValue]];      
+    
+    UVCValue    *curValue = [self currentValue];
+    if ( curValue ) [asString appendFormat:@"\n  current-value: %@", [curValue stringValue]]; 
+    
     [asString appendString:@"\n}"];
     
     NSString      *outString = [[asString copy] autorelease];
@@ -1513,6 +1536,11 @@ NSString *UVCTerminalControlPanTiltRelative = @"pan-tilt-rel";
 NSString *UVCTerminalControlRollAbsolute = @"roll-abs";
 NSString *UVCTerminalControlRollRelative = @"roll-rel";
 NSString *UVCTerminalControlPrivacy = @"privacy";
+NSString *UVCTerminalControlFocusSimple = @"focus-simple";
+NSString *UVCTerminalControlWindow = @"window";
+NSString *UVCTerminalControlRegionOfInterest = @"region-of-interest";
+
+//
 
 NSString *UVCProcessingUnitControlBacklightCompensation = @"backlight-compensation";
 NSString *UVCProcessingUnitControlBrightness = @"brightness";
@@ -1532,3 +1560,5 @@ NSString *UVCProcessingUnitControlDigitalMultiplierLimit = @"digital-multiplier-
 NSString *UVCProcessingUnitControlAutoHue = @"auto-hue";
 NSString *UVCProcessingUnitControlAnalogVideoStandard = @"analog-video-standard";
 NSString *UVCProcessingUnitControlAnalogLockStatus = @"analog-lock-status";
+NSString *UVCProcessingUnitControlAutoContrast = @"contrast-auto-control";
+

--- a/src/UVCController.m
+++ b/src/UVCController.m
@@ -10,7 +10,7 @@
 // $Id$
 //
 
-#define DEBUG_WRITE_HEADER_TO_FILE
+//#define DEBUG_WRITE_UVC_HEADER_TO_FILE
 
 #import "UVCController.h"
 
@@ -272,7 +272,7 @@ typedef struct {
   Macro that expands a list of UVCControllerControls field values into a struct
   initializer statement.
 */
-#define UVC_CONTROL_INIT(U,S,T) { .unitType = (U), .unitTypeStr = @"#U", .selector = (S), .uvcTypeDescription = (T), .uvcType = nil }
+#define UVC_CONTROL_INIT(U,S,T) { .unitType = (U), .unitTypeStr = @#U, .selector = (S), .uvcTypeDescription = (T), .uvcType = nil }
 
 /*!
   @constant UVCControllerControls
@@ -856,8 +856,8 @@ uvc_control_t     UVCControllerControls[] = {
           void                                  *basePtr = (void*)vcHeader;
           void                                  *endPtr = basePtr + vcHeader->wTotalLength;
           
+#ifdef DEBUG_WRITE_UVC_HEADER_TO_FILE
           // Dump the header to a file for debugging:
-#ifdef DEBUG_WRITE_HEADER_TO_FILE
           char                                  headerFName[64];
           
           snprintf(headerFName, sizeof(headerFName), "uvc-header-%hhu.bin", vcHeader->baInterfaceNr1);

--- a/src/UVCController.m
+++ b/src/UVCController.m
@@ -10,6 +10,8 @@
 // $Id$
 //
 
+#define DEBUG_WRITE_HEADER_TO_FILE
+
 #import "UVCController.h"
 
 //
@@ -853,7 +855,21 @@ uvc_control_t     UVCControllerControls[] = {
           UVC_VC_Interface_Header_Descriptor    *vcHeader = (UVC_VC_Interface_Header_Descriptor*)interfaceDescriptor;
           void                                  *basePtr = (void*)vcHeader;
           void                                  *endPtr = basePtr + vcHeader->wTotalLength;
-
+          
+          // Dump the header to a file for debugging:
+#ifdef DEBUG_WRITE_HEADER_TO_FILE
+          char                                  headerFName[64];
+          
+          snprintf(headerFName, sizeof(headerFName), "uvc-header-%hhu.bin", vcHeader->baInterfaceNr1);
+          
+          FILE                                  *headerFPtr = fopen(headerFName, "w");
+          
+          if ( headerFPtr ) {
+            fwrite(basePtr, vcHeader->wTotalLength, 1, headerFPtr);
+            fclose(headerFPtr);
+          }
+#endif
+          
           // Grab the version of the UVC standard this device implements:
           _uvcVersion = NSSwapLittleShortToHost(vcHeader->bcdUVC);
 

--- a/src/UVCController.m
+++ b/src/UVCController.m
@@ -282,7 +282,7 @@ typedef struct {
 */
 uvc_control_t     UVCControllerControls[] = {
                       UVC_CONTROL_INIT(UVC_INPUT_TERMINAL_ID, CT_SCANNING_MODE_CONTROL, "{B}"),
-                      UVC_CONTROL_INIT(UVC_INPUT_TERMINAL_ID, CT_AE_MODE_CONTROL, "{U1}"),
+                      UVC_CONTROL_INIT(UVC_INPUT_TERMINAL_ID, CT_AE_MODE_CONTROL, "{M}"),
                       UVC_CONTROL_INIT(UVC_INPUT_TERMINAL_ID, CT_AE_PRIORITY_CONTROL, "{U1}"),
                       UVC_CONTROL_INIT(UVC_INPUT_TERMINAL_ID, CT_EXPOSURE_TIME_ABSOLUTE_CONTROL, "{U4}"),
                       UVC_CONTROL_INIT(UVC_INPUT_TERMINAL_ID, CT_EXPOSURE_TIME_RELATIVE_CONTROL, "{S1}"),
@@ -1483,6 +1483,7 @@ uvc_control_t     UVCControllerControls[] = {
     if ( [self hasDefaultValue] ) {
       [asString appendFormat:@"\n  default-value: %@", [_defaultValue stringValue]];
     }
+    [asString appendFormat:@"\n  current-value: %@", [[self currentValue]  stringValue]];      
     [asString appendString:@"\n}"];
     
     NSString      *outString = [[asString copy] autorelease];

--- a/src/UVCController.m
+++ b/src/UVCController.m
@@ -1560,5 +1560,5 @@ NSString *UVCProcessingUnitControlDigitalMultiplierLimit = @"digital-multiplier-
 NSString *UVCProcessingUnitControlAutoHue = @"auto-hue";
 NSString *UVCProcessingUnitControlAnalogVideoStandard = @"analog-video-standard";
 NSString *UVCProcessingUnitControlAnalogLockStatus = @"analog-lock-status";
-NSString *UVCProcessingUnitControlAutoContrast = @"contrast-auto-control";
+NSString *UVCProcessingUnitControlAutoContrast = @"auto-contrast";
 

--- a/src/UVCType.h
+++ b/src/UVCType.h
@@ -27,10 +27,13 @@ typedef enum {
   kUVCTypeComponentTypeBitmap8,
   kUVCTypeComponentTypeSInt16,
   kUVCTypeComponentTypeUInt16,
+  kUVCTypeComponentTypeBitmap16,
   kUVCTypeComponentTypeSInt32,
   kUVCTypeComponentTypeUInt32,
+  kUVCTypeComponentTypeBitmap32,
   kUVCTypeComponentTypeSInt64,
   kUVCTypeComponentTypeUInt64,
+  kUVCTypeComponentTypeBitmap64,
   kUVCTypeComponentTypeMax
 } UVCTypeComponentType;
 
@@ -112,12 +115,16 @@ typedef enum {
     B         UInt8, accepting only 0 and 1
     S1        SInt8 / char
     U1        UInt8 / unsigned char
+    M1        UInt8 / unsigned char as a bitmap
     S2        SInt16 / short
     U2        UInt16 / unsigned short
+    M2        UInt16 / unsigned short as a bitmap
     S4        SInt32 / int
     U4        UInt32 / unsigned int
+    M4        UInt32 / unsigned int as a bitmap
     S8        SInt64 / long long int
     U8        UInt64 / unsigned long long int
+    M8        UInt64 / unsigned long long int as a bitmap
   
   For types with a single field, the [name] can be omitted:
   

--- a/src/UVCType.h
+++ b/src/UVCType.h
@@ -24,6 +24,7 @@ typedef enum {
   kUVCTypeComponentTypeBoolean,
   kUVCTypeComponentTypeSInt8,
   kUVCTypeComponentTypeUInt8,
+  kUVCTypeComponentTypeBitmap8,
   kUVCTypeComponentTypeSInt16,
   kUVCTypeComponentTypeUInt16,
   kUVCTypeComponentTypeSInt32,

--- a/src/UVCType.m
+++ b/src/UVCType.m
@@ -28,10 +28,13 @@ UVCTypeComponentByteSize(UVCTypeComponentType componentType)
                         1,
                         2,
                         2,
+                        2,
+                        4,
                         4,
                         4,
                         8,
                         8,
+                        8
                       };
   if ( componentType < kUVCTypeComponentTypeMax ) return byteSizes[componentType];
   return 0;
@@ -47,13 +50,16 @@ __UVCTypeComponentTypeString(UVCTypeComponentType componentType)
                         "B",
                         "S1",
                         "U1",
-                        "M"
+                        "M1"
                         "S2",
                         "U2",
+                        "M2",
                         "S4",
                         "U4",
+                        "M4",
                         "S8",
                         "U8",
+                        "M8"
                       };
   if ( componentType < kUVCTypeComponentTypeMax ) return typeStrings[componentType];
   return 0;
@@ -72,10 +78,13 @@ __UVCTypeComponentVerboseTypeString(UVCTypeComponentType componentType)
                         "unsigned 8-bit bitmap",
                         "signed 16-bit integer",
                         "unsigned 16-bit integer",
+                        "unsigned 16-bit bitmap",
                         "signed 32-bit integer",
                         "unsigned 32-bit integer",
+                        "unsigned 32-bit bitmap",
                         "signed 64-bit integer",
                         "unsigned 64-bit integer",
+                        "unsigned 64-bit bitmap"
                       };
   if ( componentType < kUVCTypeComponentTypeMax ) return verboseTypeStrings[componentType];
   return 0;
@@ -99,15 +108,34 @@ __UVCTypeComponentTypeFromString(
   
   switch ( *typeDefString ) {
     
-    case 'B': {
+    case 'B':
+    case 'b': {
       outType = kUVCTypeComponentTypeBoolean;
       charConsumed++;
       break;
     }
     
-    case 'M': {
-      outType = kUVCTypeComponentTypeBitmap8;
+    case 'M':
+    case 'm': {
       charConsumed++;
+      switch ( *(typeDefString + 1) ) {
+        case '1':
+          outType = kUVCTypeComponentTypeBitmap8;
+          charConsumed++;
+          break;
+        case '2':
+          outType = kUVCTypeComponentTypeBitmap16;
+          charConsumed++;
+          break;
+        case '4':
+          outType = kUVCTypeComponentTypeBitmap32;
+          charConsumed++;
+          break;
+        case '8':
+          outType = kUVCTypeComponentTypeBitmap64;
+          charConsumed++;
+          break;
+      }
       break;
     }
     
@@ -216,6 +244,7 @@ __UVCTypeComponentTypeScanf(
         break;
       }
       
+      case kUVCTypeComponentTypeBitmap16:
       case kUVCTypeComponentTypeUInt16: {
         UInt16            *def = (UInt16*)theDefaultValue;
         
@@ -230,6 +259,7 @@ __UVCTypeComponentTypeScanf(
         break;
       }
       
+      case kUVCTypeComponentTypeBitmap32:
       case kUVCTypeComponentTypeUInt32:  {
         UInt32            *def = (UInt32*)theDefaultValue;
         
@@ -244,6 +274,7 @@ __UVCTypeComponentTypeScanf(
         break;
       }
       
+      case kUVCTypeComponentTypeBitmap64:
       case kUVCTypeComponentTypeUInt64:  {
         UInt64            *def = (UInt64*)theDefaultValue;
         
@@ -289,6 +320,7 @@ __UVCTypeComponentTypeScanf(
         break;
       }
       
+      case kUVCTypeComponentTypeBitmap16:
       case kUVCTypeComponentTypeUInt16: {
         UInt16            *def = (UInt16*)theMinimum;
         
@@ -303,6 +335,7 @@ __UVCTypeComponentTypeScanf(
         break;
       }
       
+      case kUVCTypeComponentTypeBitmap32:
       case kUVCTypeComponentTypeUInt32:  {
         UInt32            *def = (UInt32*)theMinimum;
         
@@ -317,6 +350,7 @@ __UVCTypeComponentTypeScanf(
         break;
       }
       
+      case kUVCTypeComponentTypeBitmap64:
       case kUVCTypeComponentTypeUInt64:  {
         UInt64            *def = (UInt64*)theMinimum;
         
@@ -362,6 +396,7 @@ __UVCTypeComponentTypeScanf(
         break;
       }
       
+      case kUVCTypeComponentTypeBitmap16:
       case kUVCTypeComponentTypeUInt16: {
         UInt16            *def = (UInt16*)theMaximum;
         
@@ -376,6 +411,7 @@ __UVCTypeComponentTypeScanf(
         break;
       }
       
+      case kUVCTypeComponentTypeBitmap32:
       case kUVCTypeComponentTypeUInt32:  {
         UInt32            *def = (UInt32*)theMaximum;
         
@@ -390,6 +426,7 @@ __UVCTypeComponentTypeScanf(
         break;
       }
       
+      case kUVCTypeComponentTypeBitmap64:
       case kUVCTypeComponentTypeUInt64:  {
         UInt64            *def = (UInt64*)theMaximum;
         
@@ -544,7 +581,6 @@ __UVCTypeComponentTypeScanf(
           }
           
           case kUVCTypeComponentTypeBoolean:
-          case kUVCTypeComponentTypeBitmap8:
           case kUVCTypeComponentTypeUInt8: {
             UInt8       *min = (UInt8*)theMinimum;
             UInt8       *max = (UInt8*)theMaximum;
@@ -563,6 +599,19 @@ __UVCTypeComponentTypeScanf(
                 }
               }
             }
+            *((UInt8*)theValue) = val;
+            break;
+          }
+          
+          case kUVCTypeComponentTypeBitmap8: {
+            UInt8       *min = (UInt8*)theMinimum;
+            UInt8       *max = (UInt8*)theMaximum;
+            UInt8       *res = (UInt8*)theStepSize;
+            UInt8       val = round(*min + fractionalValue * (*max - *min));
+            
+            // Mask to only the available bits:
+            if ( res ) val &= *res;
+            
             *((UInt8*)theValue) = val;
             break;
           }
@@ -611,6 +660,19 @@ __UVCTypeComponentTypeScanf(
             break;
           }
           
+          case kUVCTypeComponentTypeBitmap16: {
+            UInt16      *min = (UInt16*)theMinimum;
+            UInt16      *max = (UInt16*)theMaximum;
+            UInt16      *res = (UInt16*)theStepSize;
+            UInt16      val = round(*min + fractionalValue * (*max - *min));
+            
+            // Mask to only the available bits:
+            if ( res ) val &= *res;
+            
+            *((UInt16*)theValue) = val;
+            break;
+          }
+          
           case kUVCTypeComponentTypeSInt32: {
             SInt32      *min = (SInt32*)theMinimum;
             SInt32      *max = (SInt32*)theMaximum;
@@ -655,6 +717,19 @@ __UVCTypeComponentTypeScanf(
             break;
           }
           
+          case kUVCTypeComponentTypeBitmap32: {
+            UInt32      *min = (UInt32*)theMinimum;
+            UInt32      *max = (UInt32*)theMaximum;
+            UInt32      *res = (UInt32*)theStepSize;
+            UInt32      val = round(*min + fractionalValue * (*max - *min));
+            
+            // Mask to only the available bits:
+            if ( res ) val &= *res;
+            
+            *((UInt32*)theValue) = val;
+            break;
+          }
+          
           case kUVCTypeComponentTypeSInt64: {
             SInt64      *min = (SInt64*)theMinimum;
             SInt64      *max = (SInt64*)theMaximum;
@@ -695,6 +770,19 @@ __UVCTypeComponentTypeScanf(
                 }
               }
             }
+            *((UInt64*)theValue) = val;
+            break;
+          }
+          
+          case kUVCTypeComponentTypeBitmap64: {
+            UInt64      *min = (UInt64*)theMinimum;
+            UInt64      *max = (UInt64*)theMaximum;
+            UInt64      *res = (UInt64*)theStepSize;
+            UInt64      val = round(*min + fractionalValue * (*max - *min));
+            
+            // Mask to only the available bits:
+            if ( res ) val &= *res;
+            
             *((UInt64*)theValue) = val;
             break;
           }
@@ -755,18 +843,6 @@ __UVCTypeComponentTypeScanf(
         break;
       }
       
-        case kUVCTypeComponentTypeBitmap8: {          
-          UInt8       val;
-          
-          if ( sscanf(cString, "%hhi%n", &val, &n) == 1 ) {
-            *((UInt8*)theValue) = val;
-            rc = true;
-          } else {
-            if ( (flags & kUVCTypeScanFlagShowWarnings) ) fprintf(stderr, "WARNING: Unable to scan integer/bitmap value at '%s'\n", cString);
-          }
-          break;
-        }
-      
       case kUVCTypeComponentTypeBoolean: {
         UInt8       val;
         
@@ -785,7 +861,7 @@ __UVCTypeComponentTypeScanf(
         UInt8       *res = (UInt8*)theStepSize;
         UInt8       val;
         
-        if ( sscanf(cString, "%hhi%n", &val, &n) == 1 ) {
+        if ( sscanf(cString, "%hhu%n", &val, &n) == 1 ) {
           // Check against ranges:
           if ( min && (val < *min) ) val = *min;
           else if ( max && (val > *max) ) val = *max;
@@ -806,6 +882,28 @@ __UVCTypeComponentTypeScanf(
           rc = true;
         } else {
           if ( (flags & kUVCTypeScanFlagShowWarnings) ) fprintf(stderr, "WARNING: Unable to scan integer value at '%s'\n", cString);
+        }
+        break;
+      }
+      
+      case kUVCTypeComponentTypeBitmap8: {
+        UInt8       *min = (UInt8*)theMinimum;
+        UInt8       *max = (UInt8*)theMaximum;
+        UInt8       *res = (UInt8*)theStepSize;
+        UInt8       val;
+        
+        if ( sscanf(cString, "%hhu%n", &val, &n) == 1 ) {
+          // Check against ranges:
+          if ( min && (val < *min) ) val = *min;
+          else if ( max && (val > *max) ) val = *max;
+          
+          // Mask to available bits only:
+          if ( res ) val &= *res;
+          
+          *((UInt8*)theValue) = val;
+          rc = true;
+        } else {
+          if ( (flags & kUVCTypeScanFlagShowWarnings) ) fprintf(stderr, "WARNING: Unable to scan bitmap value at '%s'\n", cString);
         }
         break;
       }
@@ -849,7 +947,7 @@ __UVCTypeComponentTypeScanf(
         UInt16      *res = (UInt16*)theStepSize;
         UInt16      val;
         
-        if ( sscanf(cString, "%hi%n", &val, &n) == 1 ) {
+        if ( sscanf(cString, "%hu%n", &val, &n) == 1 ) {
           // Check against ranges:
           if ( min && (val < *min) ) val = *min;
           else if ( max && (val > *max) ) val = *max;
@@ -870,6 +968,28 @@ __UVCTypeComponentTypeScanf(
           rc = true;
         } else {
           if ( (flags & kUVCTypeScanFlagShowWarnings) ) fprintf(stderr, "WARNING: Unable to scan integer value at '%s'\n", cString);
+        }
+        break;
+      }
+      
+      case kUVCTypeComponentTypeBitmap16: {
+        UInt16      *min = (UInt16*)theMinimum;
+        UInt16      *max = (UInt16*)theMaximum;
+        UInt16      *res = (UInt16*)theStepSize;
+        UInt16      val;
+        
+        if ( sscanf(cString, "%hu%n", &val, &n) == 1 ) {
+          // Check against ranges:
+          if ( min && (val < *min) ) val = *min;
+          else if ( max && (val > *max) ) val = *max;
+          
+          // Mask to available bits only:
+          if ( res ) val &= *res;
+          
+          *((UInt16*)theValue) = val;
+          rc = true;
+        } else {
+          if ( (flags & kUVCTypeScanFlagShowWarnings) ) fprintf(stderr, "WARNING: Unable to scan bitmap value at '%s'\n", cString);
         }
         break;
       }
@@ -913,7 +1033,7 @@ __UVCTypeComponentTypeScanf(
         UInt32      *res = (UInt32*)theStepSize;
         UInt32      val;
         
-        if ( sscanf(cString, "%i%n", &val, &n) == 1 ) {
+        if ( sscanf(cString, "%u%n", &val, &n) == 1 ) {
           // Check against ranges:
           if ( min && (val < *min) ) val = *min;
           else if ( max && (val > *max) ) val = *max;
@@ -934,6 +1054,28 @@ __UVCTypeComponentTypeScanf(
           rc = true;
         } else {
           if ( (flags & kUVCTypeScanFlagShowWarnings) ) fprintf(stderr, "WARNING: Unable to scan integer value at '%s'\n", cString);
+        }
+        break;
+      }
+      
+      case kUVCTypeComponentTypeBitmap32: {
+        UInt32      *min = (UInt32*)theMinimum;
+        UInt32      *max = (UInt32*)theMaximum;
+        UInt32      *res = (UInt32*)theStepSize;
+        UInt32      val;
+        
+        if ( sscanf(cString, "%u%n", &val, &n) == 1 ) {
+          // Check against ranges:
+          if ( min && (val < *min) ) val = *min;
+          else if ( max && (val > *max) ) val = *max;
+          
+          // Mask to available bits only:
+          if ( res ) val &= *res;
+          
+          *((UInt32*)theValue) = val;
+          rc = true;
+        } else {
+          if ( (flags & kUVCTypeScanFlagShowWarnings) ) fprintf(stderr, "WARNING: Unable to scan bitmap value at '%s'\n", cString);
         }
         break;
       }
@@ -975,7 +1117,7 @@ __UVCTypeComponentTypeScanf(
         UInt64      *res = (UInt64*)theStepSize;
         UInt64      val;
         
-        if ( sscanf(cString, "%lli%n", &val, &n) == 1 ) {
+        if ( sscanf(cString, "%llu%n", &val, &n) == 1 ) {
           // Check against ranges:
           if ( min && (val < *min) ) val = *min;
           else if ( max && (val > *max) ) val = *max;
@@ -996,6 +1138,28 @@ __UVCTypeComponentTypeScanf(
           rc = true;
         } else {
           if ( (flags & kUVCTypeScanFlagShowWarnings) ) fprintf(stderr, "WARNING: Unable to scan integer value at '%s'\n", cString);
+        }
+        break;
+      }
+      
+      case kUVCTypeComponentTypeBitmap64: {
+        UInt64      *min = (UInt64*)theMinimum;
+        UInt64      *max = (UInt64*)theMaximum;
+        UInt64      *res = (UInt64*)theStepSize;
+        UInt64      val;
+        
+        if ( sscanf(cString, "%llu%n", &val, &n) == 1 ) {
+          // Check against ranges:
+          if ( min && (val < *min) ) val = *min;
+          else if ( max && (val > *max) ) val = *max;
+          
+          // Mask to available bits only:
+          if ( res ) val &= *res;
+          
+          *((UInt64*)theValue) = val;
+          rc = true;
+        } else {
+          if ( (flags & kUVCTypeScanFlagShowWarnings) ) fprintf(stderr, "WARNING: Unable to scan bitmap value at '%s'\n", cString);
         }
         break;
       }
@@ -1418,7 +1582,8 @@ typedef struct {
           buffer++;
           break;
         case kUVCTypeComponentTypeSInt16:
-        case kUVCTypeComponentTypeUInt16: {
+        case kUVCTypeComponentTypeUInt16:
+        case kUVCTypeComponentTypeBitmap16: {
           UInt16   *asInt16Ptr = (UInt16*)buffer;
           
           *asInt16Ptr = NSSwapHostShortToLittle(*asInt16Ptr);
@@ -1426,7 +1591,8 @@ typedef struct {
           break;
         }
         case kUVCTypeComponentTypeSInt32:
-        case kUVCTypeComponentTypeUInt32: {
+        case kUVCTypeComponentTypeUInt32:
+        case kUVCTypeComponentTypeBitmap32: {
           UInt32   *asInt32Ptr = (UInt32*)buffer;
           
           *asInt32Ptr = NSSwapHostIntToLittle(*asInt32Ptr);
@@ -1434,7 +1600,8 @@ typedef struct {
           break;
         }
         case kUVCTypeComponentTypeSInt64:
-        case kUVCTypeComponentTypeUInt64: {
+        case kUVCTypeComponentTypeUInt64:
+        case kUVCTypeComponentTypeBitmap64: {
           UInt64   *asInt64Ptr = (UInt64*)buffer;
           
           *asInt64Ptr = NSSwapHostLongLongToLittle(*asInt64Ptr);
@@ -1468,7 +1635,8 @@ typedef struct {
           buffer++;
           break;
         case kUVCTypeComponentTypeSInt16:
-        case kUVCTypeComponentTypeUInt16: {
+        case kUVCTypeComponentTypeUInt16:
+        case kUVCTypeComponentTypeBitmap16: {
           UInt16   *asInt16Ptr = (UInt16*)buffer;
           
           *asInt16Ptr = NSSwapLittleShortToHost(*asInt16Ptr);
@@ -1476,7 +1644,8 @@ typedef struct {
           break;
         }
         case kUVCTypeComponentTypeSInt32:
-        case kUVCTypeComponentTypeUInt32: {
+        case kUVCTypeComponentTypeUInt32:
+        case kUVCTypeComponentTypeBitmap32: {
           UInt32   *asInt32Ptr = (UInt32*)buffer;
           
           *asInt32Ptr = NSSwapLittleIntToHost(*asInt32Ptr);
@@ -1484,7 +1653,8 @@ typedef struct {
           break;
         }
         case kUVCTypeComponentTypeSInt64:
-        case kUVCTypeComponentTypeUInt64: {
+        case kUVCTypeComponentTypeUInt64:
+        case kUVCTypeComponentTypeBitmap64: {
           UInt64   *asInt64Ptr = (UInt64*)buffer;
           
           *asInt64Ptr = NSSwapLittleLongLongToHost(*asInt64Ptr);
@@ -1723,26 +1893,29 @@ typedef struct {
         case kUVCTypeComponentTypeSInt8: {
           return [NSString stringWithFormat:@"%hhd", *((SInt8*)buffer)];
         }
-        case kUVCTypeComponentTypeBitmap8:
-        case kUVCTypeComponentTypeUInt8: {
+        case kUVCTypeComponentTypeUInt8:
+        case kUVCTypeComponentTypeBitmap8: {
           return [NSString stringWithFormat:@"%hhu", *((UInt8*)buffer)];
         }
         case kUVCTypeComponentTypeSInt16: {
           return [NSString stringWithFormat:@"%hd", *((SInt16*)buffer)];
         }
-        case kUVCTypeComponentTypeUInt16: {
+        case kUVCTypeComponentTypeUInt16:
+        case kUVCTypeComponentTypeBitmap16: {
           return [NSString stringWithFormat:@"%hu", *((UInt16*)buffer)];
         }
         case kUVCTypeComponentTypeSInt32: {
           return [NSString stringWithFormat:@"%d", *((SInt32*)buffer)];
         }
-        case kUVCTypeComponentTypeUInt32: {
+        case kUVCTypeComponentTypeUInt32:
+        case kUVCTypeComponentTypeBitmap32: {
           return [NSString stringWithFormat:@"%u", *((UInt32*)buffer)];
         }
         case kUVCTypeComponentTypeSInt64: {
           return [NSString stringWithFormat:@"%lld", *((SInt64*)buffer)];
         }
-        case kUVCTypeComponentTypeUInt64: {
+        case kUVCTypeComponentTypeUInt64:
+        case kUVCTypeComponentTypeBitmap64: {
           return [NSString stringWithFormat:@"%llu", *((UInt64*)buffer)];
         }
         case kUVCTypeComponentTypeMax:
@@ -1762,21 +1935,15 @@ typedef struct {
           shouldIncludeComma = YES;
           buffer++;
           break;
-        }
-        case kUVCTypeComponentTypeBitmap8: {
-            [asString appendFormat:@"%s%@=%hhu", shouldIncludeComma ? "," : "", FIELD_PTR->fieldName, *((UInt8*)buffer)];
-            shouldIncludeComma = YES;
-            buffer++;
-            break;
-          }
-              
+        }     
         case kUVCTypeComponentTypeSInt8: {
           [asString appendFormat:@"%s%@=%hhd", shouldIncludeComma ? "," : "", FIELD_PTR->fieldName, *((SInt8*)buffer)];
           shouldIncludeComma = YES;
           buffer++;
           break;
         }
-        case kUVCTypeComponentTypeUInt8: {
+        case kUVCTypeComponentTypeUInt8:
+        case kUVCTypeComponentTypeBitmap8: {
           [asString appendFormat:@"%s%@=%hhu", shouldIncludeComma ? "," : "", FIELD_PTR->fieldName, *((UInt8*)buffer)];
           shouldIncludeComma = YES;
           buffer++;
@@ -1788,7 +1955,8 @@ typedef struct {
           buffer += 2;
           break;
         }
-        case kUVCTypeComponentTypeUInt16: {
+        case kUVCTypeComponentTypeUInt16:
+        case kUVCTypeComponentTypeBitmap16: {
           [asString appendFormat:@"%s%@=%hu", shouldIncludeComma ? "," : "", FIELD_PTR->fieldName, *((UInt16*)buffer)];
           shouldIncludeComma = YES;
           buffer += 2;
@@ -1800,7 +1968,8 @@ typedef struct {
           buffer += 4;
           break;
         }
-        case kUVCTypeComponentTypeUInt32: {
+        case kUVCTypeComponentTypeUInt32:
+        case kUVCTypeComponentTypeBitmap32: {
           [asString appendFormat:@"%s%@=%u", shouldIncludeComma ? "," : "", FIELD_PTR->fieldName, *((UInt32*)buffer)];
           shouldIncludeComma = YES;
           buffer += 4;
@@ -1812,7 +1981,8 @@ typedef struct {
           buffer += 8;
           break;
         }
-        case kUVCTypeComponentTypeUInt64: {
+        case kUVCTypeComponentTypeUInt64:
+        case kUVCTypeComponentTypeBitmap64: {
           [asString appendFormat:@"%s%@=%llu", shouldIncludeComma ? "," : "", FIELD_PTR->fieldName, *((UInt64*)buffer)];
           shouldIncludeComma = YES;
           buffer += 8;

--- a/src/UVCType.m
+++ b/src/UVCType.m
@@ -565,14 +565,14 @@ __UVCTypeComponentTypeScanf(
             SInt8       val = round(*min + fractionalValue * (*max - *min));
             
             // Fix to the appropriate resolution if applicable:
-            if ( res && (*res > 1) ) {
-              SInt8     residual = (val % *res);
+            if ( min && max && res && (*res > 1) ) {
+              SInt8     residual = ((val - *min) % *res);
 
               if ( residual != 0 ) {
                 if ( residual >= (*res / 2) ) {
-                  val += *res - residual;
+                  val = val + (*res - residual);
                 } else {
-                  val -= residual;
+                  val = val - residual;
                 }
               }
             }
@@ -588,14 +588,14 @@ __UVCTypeComponentTypeScanf(
             UInt8       val = round(*min + fractionalValue * (*max - *min));
             
             // Fix to the appropriate resolution if applicable:
-            if ( res && (*res > 1) ) {
-              UInt8     residual = (val % *res);
+            if ( min && max && res && (*res > 1) ) {
+              UInt8     residual = ((val - *min) % *res);
 
               if ( residual != 0 ) {
                 if ( residual >= (*res / 2) ) {
-                  val += *res - residual;
+                  val = val + (*res - residual);
                 } else {
-                  val -= residual;
+                  val = val - residual;
                 }
               }
             }
@@ -623,14 +623,14 @@ __UVCTypeComponentTypeScanf(
             SInt16      val = round(*min + fractionalValue * (*max - *min));
             
             // Fix to the appropriate resolution if applicable:
-            if ( res && (*res > 1) ) {
-              SInt16    residual = (val % *res);
+            if ( min && max && res && (*res > 1) ) {
+              SInt16    residual = ((val - *min) % *res);
 
               if ( residual != 0 ) {
                 if ( residual >= (*res / 2) ) {
-                  val += *res - residual;
+                  val = val + (*res - residual);
                 } else {
-                  val -= residual;
+                  val = val - residual;
                 }
               }
             }
@@ -645,14 +645,14 @@ __UVCTypeComponentTypeScanf(
             UInt16      val = round(*min + fractionalValue * (*max - *min));
             
             // Fix to the appropriate resolution if applicable:
-            if ( res && (*res > 1) ) {
-              UInt16    residual = (val % *res);
+            if ( min && max && res && (*res > 1) ) {
+              UInt16    residual = ((val - *min) % *res);
 
               if ( residual != 0 ) {
                 if ( residual >= (*res / 2) ) {
-                  val += *res - residual;
+                  val = val + (*res - residual);
                 } else {
-                  val -= residual;
+                  val = val - residual;
                 }
               }
             }
@@ -680,14 +680,14 @@ __UVCTypeComponentTypeScanf(
             SInt32      val = round(*min + fractionalValue * (*max - *min));
             
             // Fix to the appropriate resolution if applicable:
-            if ( res && (*res > 1) ) {
-              SInt32    residual = (val % *res);
+            if ( min && max && res && (*res > 1) ) {
+              SInt32    residual = ((val - *min) % *res);
 
               if ( residual != 0 ) {
                 if ( residual >= (*res / 2) ) {
-                  val += *res - residual;
+                  val = val + (*res - residual);
                 } else {
-                  val -= residual;
+                  val = val - residual;
                 }
               }
             }
@@ -702,14 +702,14 @@ __UVCTypeComponentTypeScanf(
             UInt32      val = round(*min + fractionalValue * (*max - *min));
             
             // Fix to the appropriate resolution if applicable:
-            if ( res && (*res > 1) ) {
-              UInt32    residual = (val % *res);
+            if ( min && max && res && (*res > 1) ) {
+              UInt32    residual = ((val - *min) % *res);
 
               if ( residual != 0 ) {
                 if ( residual >= (*res / 2) ) {
-                  val += *res - residual;
+                  val = val + (*res - residual);
                 } else {
-                  val -= residual;
+                  val = val - residual;
                 }
               }
             }
@@ -737,14 +737,14 @@ __UVCTypeComponentTypeScanf(
             SInt64      val = round(*min + fractionalValue * (*max - *min));
             
             // Fix to the appropriate resolution if applicable:
-            if ( res && (*res > 1) ) {
-              SInt64    residual = (val % *res);
+            if ( min && max && res && (*res > 1) ) {
+              SInt64    residual = ((val - *min) % *res);
 
               if ( residual != 0 ) {
                 if ( residual >= (*res / 2) ) {
-                  val += *res - residual;
+                  val = val + (*res - residual);
                 } else {
-                  val -= residual;
+                  val = val - residual;
                 }
               }
             }
@@ -759,14 +759,14 @@ __UVCTypeComponentTypeScanf(
             UInt64      val = round(*min + fractionalValue * (*max - *min));
             
             // Fix to the appropriate resolution if applicable:
-            if ( res && (*res > 1) ) {
-              UInt64    residual = (val % *res);
+            if ( min && max && res && (*res > 1) ) {
+              UInt64    residual = ((val - *min) % *res);
 
               if ( residual != 0 ) {
                 if ( residual >= (*res / 2) ) {
-                  val += *res - residual;
+                  val = val + (*res - residual);
                 } else {
-                  val -= residual;
+                  val = val - residual;
                 }
               }
             }
@@ -822,14 +822,14 @@ __UVCTypeComponentTypeScanf(
           else if ( max && (val > *max) ) val = *max;
           
           // Fix to the appropriate resolution if applicable:
-          if ( res && (*res > 1) ) {
-            SInt8     residual = (val % *res);
+          if ( min && max && res && (*res > 1) ) {
+            SInt16   residual = ((val - *min) % *res);
 
             if ( residual != 0 ) {
               if ( residual >= (*res / 2) ) {
-                val += *res - residual;
+                val = val + (*res - residual);
               } else {
-                val -= residual;
+                val = val - residual;
               }
             }
           }
@@ -867,14 +867,14 @@ __UVCTypeComponentTypeScanf(
           else if ( max && (val > *max) ) val = *max;
           
           // Fix to the appropriate resolution if applicable:
-          if ( res && (*res > 1) ) {
-            UInt8     residual = (val % *res);
+          if ( min && max && res && (*res > 1) ) {
+            UInt8    residual = ((val - *min) % *res);
 
             if ( residual != 0 ) {
               if ( residual >= (*res / 2) ) {
-                val += *res - residual;
+                val = val + (*res - residual);
               } else {
-                val -= residual;
+                val = val - residual;
               }
             }
           }
@@ -920,14 +920,14 @@ __UVCTypeComponentTypeScanf(
           else if ( max && (val > *max) ) val = *max;
           
           // Fix to the appropriate resolution if applicable:
-          if ( res && (*res > 1) ) {
-            SInt16    residual = (val % *res);
+          if ( min && max && res && (*res > 1) ) {
+            SInt32   residual = ((val - *min) % *res);
 
             if ( residual != 0 ) {
               if ( residual >= (*res / 2) ) {
-                val += *res - residual;
+                val = val + (*res - residual);
               } else {
-                val -= residual;
+                val = val - residual;
               }
             }
           }
@@ -953,14 +953,14 @@ __UVCTypeComponentTypeScanf(
           else if ( max && (val > *max) ) val = *max;
           
           // Fix to the appropriate resolution if applicable:
-          if ( res && (*res > 1) ) {
-            UInt16    residual = (val % *res);
+          if ( min && max && res && (*res > 1) ) {
+            UInt16   residual = ((val - *min) % *res);
 
             if ( residual != 0 ) {
               if ( residual >= (*res / 2) ) {
-                val += *res - residual;
+                val = val + (*res - residual);
               } else {
-                val -= residual;
+                val = val - residual;
               }
             }
           }
@@ -1006,14 +1006,14 @@ __UVCTypeComponentTypeScanf(
           else if ( max && (val > *max) ) val = *max;
           
           // Fix to the appropriate resolution if applicable:
-          if ( res && (*res > 1) ) {
-            SInt32    residual = (val % *res);
+          if ( min && max && res && (*res > 1) ) {
+            SInt64   residual = ((val - *min) % *res);
 
             if ( residual != 0 ) {
               if ( residual >= (*res / 2) ) {
-                val += *res - residual;
+                val = val + (*res - residual);
               } else {
-                val -= residual;
+                val = val - residual;
               }
             }
           }
@@ -1039,14 +1039,14 @@ __UVCTypeComponentTypeScanf(
           else if ( max && (val > *max) ) val = *max;
           
           // Fix to the appropriate resolution if applicable:
-          if ( res && (*res > 1) ) {
-            UInt32    residual = (val % *res);
+          if ( min && max && res && (*res > 1) ) {
+            UInt32   residual = ((val - *min) % *res);
 
             if ( residual != 0 ) {
               if ( residual >= (*res / 2) ) {
-                val += *res - residual;
+                val = val + (*res - residual);
               } else {
-                val -= residual;
+                val = val - residual;
               }
             }
           }
@@ -1092,14 +1092,14 @@ __UVCTypeComponentTypeScanf(
           else if ( max && (val > *max) ) val = *max;
           
           // Fix to the appropriate resolution if applicable:
-          if ( res && (*res > 1) ) {
-            SInt64    residual = (val % *res);
+          if ( min && max && res && (*res > 1) ) {
+            SInt64   residual = ((val - *min) % *res);
 
             if ( residual != 0 ) {
               if ( residual >= (*res / 2) ) {
-                val += *res - residual;
+                val = val + (*res - residual);
               } else {
-                val -= residual;
+                val = val - residual;
               }
             }
           }
@@ -1123,14 +1123,14 @@ __UVCTypeComponentTypeScanf(
           else if ( max && (val > *max) ) val = *max;
           
           // Fix to the appropriate resolution if applicable:
-          if ( res && (*res > 1) ) {
-            UInt64    residual = (val % *res);
+          if ( min && max && res && (*res > 1) ) {
+            UInt64   residual = ((val - *min) % *res);
 
             if ( residual != 0 ) {
               if ( residual >= (*res / 2) ) {
-                val += *res - residual;
+                val = val + (*res - residual);
               } else {
-                val -= residual;
+                val = val - residual;
               }
             }
           }

--- a/src/uvc-util.m
+++ b/src/uvc-util.m
@@ -32,7 +32,7 @@
 
 static NumVersion       UVCUtilVersion = {
                             .majorRev       = 1,
-                            .minorAndBugRev = 0x10,
+                            .minorAndBugRev = 0x20,
                             .stage          = finalStage,
                             .nonRelRev      = 0
                           };

--- a/uvc-util.xcodeproj/xcshareddata/xcschemes/uvc-util.xcscheme
+++ b/uvc-util.xcodeproj/xcshareddata/xcschemes/uvc-util.xcscheme
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1240"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "3B79C7741D245EAD004A5C35"
+               BuildableName = "uvc-util"
+               BlueprintName = "uvc-util"
+               ReferencedContainer = "container:uvc-util.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "3B79C7741D245EAD004A5C35"
+            BuildableName = "uvc-util"
+            BlueprintName = "uvc-util"
+            ReferencedContainer = "container:uvc-util.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <CommandLineArguments>
+         <CommandLineArgument
+            argument = "-I 0 -S auto-exposure-mode"
+            isEnabled = "YES">
+         </CommandLineArgument>
+      </CommandLineArguments>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "3B79C7741D245EAD004A5C35"
+            BuildableName = "uvc-util"
+            BlueprintName = "uvc-util"
+            ReferencedContainer = "container:uvc-util.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
Static unit id of 2 on Processing Unit left some cameras' controls discoverable but unusable.  Modified UVCController to have a unit id map initialized with defaults, overridden when the PU header is processed.  Confirmed to work properly now.