### PR TITLE
Added the `--list-formats` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ THe program has built-in help, available via the `-h` or `--help` flag:
 ~~~~
 usage:
 
-    ./uvc-util {options/actions/target selection}
+    ./build/Release/uvc-util {options/actions/target selection}
 
   Options:
 
@@ -33,10 +33,14 @@ usage:
     -c/--list-controls                     Display a list of UVC controls available for
                                            the target device
 
-    -S <control-name>                      Display available information for the given
-    --show-control=<control-name>          UVC control:  component fields for multi-value
-                                           types, minimum, maximum, resolution, and default
-                                           value when provided:
+    -f/--list-formats                      Display video streaming formats, resolutions,
+                                           framerates, and color spaces supported by the
+                                           target device
+
+    -S (<control-name>|*)                  Display available information for the given
+    --show-control=(<control-name>|*)      UVC control (or all controls for "*").  Component
+                                           fields for multi-component controls, minimum, maximum,
+                                           resolution, and default value when provided:
 
         pan-tilt-abs {
           type-description: {
@@ -57,6 +61,8 @@ usage:
 
     -s <control-name>=<value>              Set the value of a control; see below for a
     --set=<control-name>=<value>           description of <value>
+
+    -r/--reset-all                         Reset all controls with a default value to that value
 
     Specifying <value> for -s/--set:
 

--- a/src/UVCController.h
+++ b/src/UVCController.h
@@ -178,6 +178,14 @@
 */
 - (UVCControl*) controlWithName:(NSString*)controlName;
 
+/*!
+  @method displayFormatInformation
+
+  Prints information about the video streaming formats supported by the device,
+  including resolutions, framerates, color spaces, and compression formats.
+*/
+- (void) displayFormatInformation;
+
 @end
 
 /*!

--- a/src/uvc-util.m
+++ b/src/uvc-util.m
@@ -82,6 +82,7 @@ UVCUtilVersionString(void)
 static struct option uvcUtilOptions[] = {
                                          { "list-devices",                    no_argument,       NULL, 'd' },
                                          { "list-controls",                   no_argument,       NULL, 'c' },
+                                         { "list-formats",                    no_argument,       NULL, 'f' },
                                          { "show-control",                    required_argument, NULL, 'S' },
                                          { "set",                             required_argument, NULL, 's' },
                                          { "get",                             required_argument, NULL, 'g' },
@@ -128,6 +129,10 @@ usage(
       "\n"
       "    -c/--list-controls                     Display a list of UVC controls available for\n"
       "                                           the target device\n"
+      "\n"
+      "    -f/--list-formats                      Display video streaming formats, resolutions,\n"
+      "                                           framerates, and color spaces supported by the\n"
+      "                                           target device\n"
       "\n"
       "    -S (<control-name>|*)                  Display available information for the given\n"
       "    --show-control=(<control-name>|*)      UVC control (or all controls for \"*\").  Component\n"
@@ -381,7 +386,18 @@ main(
         }
         break;
       }
-      
+
+      case 'f': {
+        if ( targetDevice ) {
+          [targetDevice displayFormatInformation];
+        } else {
+          fprintf(stderr, "ERROR:  no target device selected\n");
+          rc = ENODEV;
+          if ( exitOnErrors ) goto cleanupAndExit;
+        }
+        break;
+      }
+
       case '0': {
         targetDevice = nil;
         break;


### PR DESCRIPTION
Add video format inspection with --list-formats option

 - Add VS descriptor parsing for video streaming formats
 - Display format, resolution, FPS, bit depth, and chroma subsampling
 - Add color space information (Rec.709/Rec.601)
 - Support for YUY2, NV12, I420, P010, MJPEG formats
 - Add deduplication to avoid showing duplicate format entries